### PR TITLE
Added a check to see if tinymce is defined.

### DIFF
--- a/markdown/easy-markdown.php
+++ b/markdown/easy-markdown.php
@@ -451,7 +451,7 @@ class WPCom_Markdown {
 ?>
 <script type="text/javascript">
 jQuery( function() {
-	tinymce.on( 'AddEditor', function( event ) {
+	( 'undefined' !== typeof tinymce ) && tinymce.on( 'AddEditor', function( event ) {
 		event.editor.on( 'BeforeSetContent', function( event ) {
 			var editor = event.target;
 			Object.keys( editor.schema.elements ).forEach( function( key, index ) {


### PR DESCRIPTION
It looks like recently WordPress has changed the way TinyMCE is loading on various pages. We can no longer rely on tinymce object being present, and we can check to see if it is before registering event handlers. This lets us avoid fatal errors while remaining backwards compatible.

Signed-off-by: Igor Zinovyev <zinigor@gmail.com>

apply https://github.com/Automattic/jetpack/pull/9823